### PR TITLE
(SIMP-5396) Set tlog::rec_session::shell_hook_users default to ['root']

### DIFF
--- a/manifests/rec_session.pp
+++ b/manifests/rec_session.pp
@@ -1,6 +1,6 @@
 # Configure `tlog-rec-session`
 #
-# This is pulled out from the main `tlog` class becuase of the rapidly moving
+# This is pulled out from the main `tlog` class because of the rapidly moving
 # nature of the project. Having this decoupled will allow us to refactor as
 # necessary as the software progresses.
 #
@@ -45,7 +45,7 @@ class tlog::rec_session (
   Tlog::RecSessionConf $options,
   Hash                 $custom_options        = {},
   Boolean              $shell_hook            = true,
-  Array[String[1]]     $shell_hook_users      = [],
+  Array[String[1]]     $shell_hook_users      = [ 'root' ],
   Stdlib::Absolutepath $shell_hook_users_file = '/etc/security/tlog.users',
   Stdlib::Absolutepath $shell_hook_cmd        = '/usr/bin/tlog-rec-session'
 ) {

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -15,6 +15,7 @@ describe 'tlog' do
     # We'll be logging in directly in subsequent tests
     'ssh::server::conf::permitrootlogin'        => true,
     'ssh::server::conf::passwordauthentication' => true,
+    'ssh::server::conf::authorizedkeysfile'     => '.ssh/authorized_keys',
     'tlog::manage_rsyslog'                      => true,
     'tlog::config::rsyslog::logrotate'          => true
   }}

--- a/spec/acceptance/suites/default/10_tlog_rec_session_spec.rb
+++ b/spec/acceptance/suites/default/10_tlog_rec_session_spec.rb
@@ -14,18 +14,18 @@ describe 'tlog::rec_session' do
     'tlog::config::rsyslog::logrotate' => true
   }}
 
-  let(:enforcing_hieradata) {
+  let(:not_root_enforcing_hieradata) {
    hieradata.merge({
-     'tlog::rec_session::shell_hook_users' => [ 'root' ]
+     'tlog::rec_session::shell_hook_users' => [ ]
    })
   }
 
   hosts.each do |host|
     context "on #{host}" do
-      context 'default parameters' do
+      context 'when not enforcing for "root"' do
         # Using puppet_apply as a helper
         it 'should work with no errors' do
-          set_hieradata_on(host, hieradata)
+          set_hieradata_on(host, not_root_enforcing_hieradata)
           apply_manifest_on(host, manifest, :catch_failures => true)
         end
 
@@ -39,10 +39,10 @@ describe 'tlog::rec_session' do
         end
       end
 
-      context 'when enforcing for "root"' do
+      context 'when default parameters (enforcing for "root")' do
         # Using puppet_apply as a helper
         it 'should work with no errors' do
-          set_hieradata_on(host, enforcing_hieradata)
+          set_hieradata_on(host, hieradata)
           apply_manifest_on(host, manifest, :catch_failures => true)
         end
 


### PR DESCRIPTION
- Set default for tlog::rec_session::shell_hook_users to ['root']
  as that is a reasonable default.  This also allows a standard SIMP
  system to record 'root' actions akin to the previous sudosh
  capability, without setting anything in hieradata.  In other words,
  it works as you would expect out of the box.
- Fix acceptance test broken by latest *beaker* gem updates

SIMP-5396 # close