### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,27 +1,13 @@
 ---
 fixtures:
   repositories:
-    augeasproviders_core:
-      repo: https://github.com/simp/augeasproviders_core
-      ref: master
-    augeasproviders:ssh:
-      repo: https://github.com/simp/augeasproviders_ssh
-      ref: master
-    logrotate:
-      repo: https://github.com/simp/pupmod-simp-logrotate
-      ref: master
-    rsyslog:
-      repo: https://github.com/simp/pupmod-simp-rsyslog
-      ref: master
-    simplib:
-      repo: https://github.com/simp/pupmod-simp-simplib
-      ref: master
-    ssh:
-      repo: https://github.com/simp/pupmod-simp-ssh
-      ref: master
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
-      ref: master
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
+    augeasproviders:ssh: https://github.com/simp/augeasproviders_ssh
+    logrotate: https://github.com/simp/pupmod-simp-logrotate
+    rsyslog: https://github.com/simp/pupmod-simp-rsyslog
+    simplib: https://github.com/simp/pupmod-simp-simplib
+    ssh: https://github.com/simp/pupmod-simp-ssh
+    stdlib: https://github.com/simp/puppetlabs-stdlib
     systemd:
       repo: https://github.com/simp/puppet-systemd
       branch: simp-master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.2
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Fri Dec 14 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.1
 - Fix infinite recursion issue in the SH profile script
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/73/badge)](https://bestpractices.coreinfrastructure.org/projects/73)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/simp/tlog.svg)](https://forge.puppetlabs.com/simp/tlog)
@@ -88,7 +86,7 @@ session in json format:
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tlog",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "simp",
   "summary": "A module for managing Tlog",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-tlog