### PR TITLE
(SIMP-7578) Workaround tlog hostname failure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Tue Feb 25 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.0
+- Added EL8 support
+- Updated acceptance tests to use net/ssh to prevent issues with large SSH
+  keyrings
+- Added REFERENCE.md and linked into the README.md
+- Added optional dependencies for simp/logrotate and simp/rsyslog
+- Added workaround to scripts in /etc/profile to work around a bug in tlog that
+  would prevent logins if the system hostname could not be found
+
 * Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 0.2.0
 - Drop Puppet 4 support
 - Add Puppet 6 support

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.10.0 < 4.0.0"
+      "version_requirement": ">= 3.10.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -28,11 +28,11 @@
     "optional_dependencies": [
       {
         "name": "simp/logrotate",
-        "version_requirement": ">= 6.5.0 < 7.0.0"
+        "version_requirement": ">= 6.4.0 < 7.0.0"
       },
       {
         "name": "simp/rsyslog",
-        "version_requirement": ">= 7.6.0 < 8.0.0"
+        "version_requirement": ">= 7.5.0 < 8.0.0"
       }
     ]
   },

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -129,6 +129,8 @@ RSpec.configure do |c|
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
+    Puppet[:digest_algorithm] = 'sha256'
+
 
     # sanitize hieradata
     if defined?(hieradata)

--- a/templates/etc/profile.d/tlog.csh.epp
+++ b/templates/etc/profile.d/tlog.csh.epp
@@ -58,7 +58,14 @@ if ( ! ($?TLOG_RUNNING) ) then
           set TLOG_PASSTHROUGH_CMD=`ps --no-headers -o args $$ | grep -oe "$TLOG_PATTERN"`
 
           if ( "$TLOG_PASSTHROUGH_CMD" == "" ) then
-            exec $TLOG_CMD
+            # Work around Tlog bug: https://github.com/Scribery/tlog/issues/269
+            if ( `hostname -f >& /dev/null` ) then
+              exec $TLOG_CMD
+            else if ( $uid == 0 ) then
+              'Tlog hostname lookup failed, emergency bypass for root'
+            else
+              exec echo 'Tlog hostname lookup failed - access denied'
+            endif
           endif
         endif
       endif

--- a/templates/etc/profile.d/tlog.csh.epp
+++ b/templates/etc/profile.d/tlog.csh.epp
@@ -62,7 +62,7 @@ if ( ! ($?TLOG_RUNNING) ) then
             if ( `hostname -f >& /dev/null` ) then
               exec $TLOG_CMD
             else if ( $uid == 0 ) then
-              'Tlog hostname lookup failed, emergency bypass for root'
+              echo 'Tlog hostname lookup failed, emergency bypass for root'
             else
               exec echo 'Tlog hostname lookup failed - access denied'
             endif

--- a/templates/etc/profile.d/tlog.sh.epp
+++ b/templates/etc/profile.d/tlog.sh.epp
@@ -53,14 +53,22 @@ if [ -t 1 ] && [ ! "${TLOG_RUNNING}" == "0" ]; then
         fi
 
         if ! ps --no-headers -o args $$ | grep -qe "-c[[:space:]]\+.\+"; then
-          TLOG_REC_SESSION_SHELL=$SHELL
+          # Work around Tlog bug: https://github.com/Scribery/tlog/issues/269
 
-          # NOTE: Currently there is a bug that affects this that means that
-          # multiple tlog sessions spawned under the same parent process (think
-          # gnome-terminal or tmux/screen windows) will no longer log commands.
-          #
-          # https://github.com/Scribery/tlog/issues/228
-          exec $TLOG_CMD
+          if hostname -f >& /dev/null; then
+            TLOG_REC_SESSION_SHELL=$SHELL
+
+            # NOTE: Currently there is a bug that affects this that means that
+            # multiple tlog sessions spawned under the same parent process (think
+            # gnome-terminal or tmux/screen windows) will no longer log commands.
+            #
+            # https://github.com/Scribery/tlog/issues/228
+            exec $TLOG_CMD
+          elif [ $UID -eq 0 ]; then
+            echo 'Tlog hostname lookup failed, emergency bypass for root'
+          else
+            exec echo 'Tlog hostname lookup failed - access denied'
+          fi
         fi
       fi
     fi


### PR DESCRIPTION
- Added workaround to scripts in /etc/profile to work around a bug in tlog that
  would prevent logins if the system hostname could not be found
- See https://github.com/Scribery/tlog/issues/269

SIMP-7578 #close