### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/centos-combined-x64.yml
+++ b/spec/acceptance/nodesets/centos-combined-x64.yml
@@ -15,7 +15,7 @@ HOSTS:
 
   el8:
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
 
 CONFIG:


### PR DESCRIPTION
- update the EL8 nodes in the acceptance tests
  to run with generic/centos8 to make sure they using
  CentOS 8.4

SIMP-10204 #comment update tlog
SIMP-10250 #close