### PR TITLE
(SIMP-10431) Fix tlog.sh.epp logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Aug 24 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.3.1
+- Fixed
+  - Corrected the logic in `tlog.sh.epp` in the case where a user does not have
+    a login shell
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.3.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tlog",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "simp",
   "summary": "A module for managing Tlog",
   "license": "Apache-2.0",

--- a/templates/etc/profile.d/tlog.sh.epp
+++ b/templates/etc/profile.d/tlog.sh.epp
@@ -39,7 +39,7 @@ fi
 # is resolved
 if [ -t 1 ] && [ ! "${TLOG_RUNNING}" == "0" ]; then
   if [ -f "${TLOG_USERS}" ]; then
-    if [ `getent passwd ${TLOG_UID} | cut -d':' -f7` != "/usr/bin/tlog-rec-session" ]; then
+    if [ "$( getent passwd ${TLOG_UID} | cut -d':' -f7 )" != "/usr/bin/tlog-rec-session" ]; then
       TLOG_UNAME=`id -nu`
 
       # Formatted for the grep below


### PR DESCRIPTION
- Fixed
  - Corrected the logic in `tlog.sh.epp` in the case where a user does not have
    a login shell

SIMP-10431 #close