### PR TITLE
(SIMP-10430) Add more support for file logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Oct 04 2021 Kendall Moore <kendall.moore@onyxpoint.com> - 0.3.2
+- Added file resource if file writer is specified
+
 * Tue Aug 24 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.3.1
 - Fixed
   - Corrected the logic in `tlog.sh.epp` in the case where a user does not have

--- a/manifests/rec_session.pp
+++ b/manifests/rec_session.pp
@@ -63,6 +63,17 @@ class tlog::rec_session (
     mode    => '0644'
   }
 
+  # Ensure the file resource exists if we are using a file writer
+  if $options['writer'] == 'file' {
+    $_tlog_output_file_opts = {
+      ensure => 'file',
+      owner  => 'tlog',
+      group  => 'tlog',
+      mode   => '0640',
+    }
+    ensure_resource('file', $options['file']['path'], $_tlog_output_file_opts)
+  }
+
   file { '/etc/tlog/tlog-rec-session.conf':
     ensure  => 'file',
     content => sprintf("%s\n", to_json(deep_merge($options, $custom_options))),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-tlog",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "simp",
   "summary": "A module for managing Tlog",
   "license": "Apache-2.0",

--- a/spec/classes/rec_session_spec.rb
+++ b/spec/classes/rec_session_spec.rb
@@ -82,6 +82,28 @@ describe 'tlog::rec_session' do
 
         end
 
+        context 'with a file writer' do
+          let(:params) {{
+            :options => {
+              'writer' => 'file',
+              'file'   => {
+                'path' => '/var/log/tlog.log'
+              }
+            }
+          }}
+
+#          it_behaves_like 'a structured module'
+
+          it { is_expected.to create_file('/var/log/tlog.log')
+            .with(
+              :ensure => 'file',
+              :owner  => 'tlog',
+              :group  => 'tlog',
+              :mode   => '0640',
+            )
+          }
+        end
+
         context 'custom_options' do
           let(:params) {{
             :custom_options => {


### PR DESCRIPTION
This ensures that a file resource will be created to manage the output
file if writer: file is specified

SIMP-10430 #close