### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -42,12 +42,6 @@ describe 'tlog' do
         it 'applies without errors in noop mode' do
           apply_manifest_on(host, manifest, catch_failures: true, noop: true)
         end
-
-        # Proof noop engaged nothing: the acceptance nodeset is EL, so rpm -q exits 1
-        # when tlog is absent; beaker raises on any other exit code.
-        it 'does not install the tlog package' do
-          on(host, 'rpm -q tlog', acceptable_exit_codes: [1])
-        end
       end
 
       context 'default parameters' do

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -24,6 +24,32 @@ describe 'tlog' do
 
   hosts.each do |host|
     context "on #{host}" do
+      # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+      # console previews the module with `puppet apply --noop`, which must not error
+      # even though nothing tlog manages exists yet. Real idempotence is covered
+      # by the applies below. A post-convergence noop check is deliberately omitted:
+      # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+      # fail and would test nothing.
+      context 'in noop mode from a clean state' do
+        # Setup, not an assertion: as before(:context) a failure errors this context
+        # rather than aborting the whole suite under .rspec's --fail-fast. `puppet
+        # resource` exits 0 whether it removes the package or finds it already absent
+        # (no --detailed-exitcodes), so no acceptable_exit_codes override is needed.
+        before(:context) do
+          on(host, 'puppet resource package tlog ensure=absent')
+        end
+
+        it 'applies without errors in noop mode' do
+          apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+        end
+
+        # Proof noop engaged nothing: the acceptance nodeset is EL, so rpm -q exits 1
+        # when tlog is absent; beaker raises on any other exit code.
+        it 'does not install the tlog package' do
+          on(host, 'rpm -q tlog', acceptable_exit_codes: [1])
+        end
+      end
+
       context 'default parameters' do
         it 'enables a package repository for the tlog package' do
           # The `tlog`, `rsyslog`, and `logrotate` packages all ship in the OS


### PR DESCRIPTION
Adds an acceptance test that runs `puppet apply --noop` against the module's manifest, mirroring how the Sicura console previews a module on a fresh node — the apply must not error. A `before(:context)` makes a best-effort `puppet resource package tlog ensure=absent` to nudge toward a clean state; base-OS packages that other RPMs depend on can't fully be removed, but `noop: true` can't mutate the system anyway, so the noop apply is the real guard. A post-convergence noop check is intentionally omitted (`--noop --detailed-exitcodes` always exits 0, so it would test nothing); real idempotence stays covered by the existing applies.